### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.10
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## [0.0.1] - 2019.07.04
 
 * initial release.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_common
 description: Flutter Common package.
-version: 0.5.9
+version: 0.5.10
 homepage: https://github.com/wiatec
 repository: https://github.com/wiatec/flutter_common
 
@@ -24,7 +24,7 @@ dependencies:
   share: ^0.6.3+4
   path_provider: ^1.4.5
   device_info: ^0.4.1+3
-  package_info: ^0.4.0+12
+  package_info: '>=0.4.0+12 <2.0.0'
   connectivity: ^0.4.5+7
   json_annotation: ^3.0.0
   shared_preferences: ^0.5.4+8


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).